### PR TITLE
Remove Metadata Explorer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -179,7 +179,7 @@ nav:
           - Decentralized Nodes: https://nodes.web3.foundation/
           - Thousand Contributors: general/thousand-contributors.md
           - Dev Heroes: general/dev-heroes.md
-      - Metadata: general/metadata.md
+      - Metadata: https://paritytech.github.io/subxt-explorer/#/
       - Chain State Values: general/chain-state-values.md
   - Learn:
       - General:


### PR DESCRIPTION
Requires constant updates and there is already a solution in the eco -> https://paritytech.github.io/subxt-explorer/#/

hence I am replacing the sidebar item with the URL