### PR TITLE
Remove anchors chain state

### DIFF
--- a/docs/build/build-protocol-info.md
+++ b/docs/build/build-protocol-info.md
@@ -149,7 +149,7 @@ valid. If the extrinsic is not included in a block within this validity window, 
 from the transaction queue.
 
 The chain only stores a limited number of prior block hashes as reference. You can query this
-parameter, called [`BlockHashCount`](../general/chain-state-values.md#block-hash-count), from the
+parameter, called [`BlockHashCount`](../general/chain-state-values.md), from the
 chain state or metadata. If the validity period is larger than the number of blocks stored on-chain,
 then the transaction will only be valid as long as there is a block to check it against, i.e. the
 minimum value of validity period and block hash count.

--- a/docs/general/dashboards/staking-dashboard.md
+++ b/docs/general/dashboards/staking-dashboard.md
@@ -27,7 +27,7 @@ that accounts on wallets or extensions can be imported from [Ledger](../ledger.m
 On top of the [existential deposit](../../learn/learn-accounts.md#existential-deposit-and-reaping), you
 need some free balance to pay for
 [transaction fees](../../learn/learn-transactions.md#transaction-fees) and
-[the minimum amount to place your nominations or join a nomination pool](../chain-state-values.md#minimum-bond-to-participate-in-staking).
+[the minimum amount to place your nominations or join a nomination pool](../chain-state-values.md).
 For more information about staking visit the [staking page](../../learn/learn-staking.md) and the
 [advanced staking page](../../learn/learn-staking-advanced.md).
 
@@ -103,7 +103,7 @@ Note that Sections A and B will always be visible while you use the dashboard.
   on-chain, see [existential deposit](../../learn/learn-accounts.md#existential-deposit-and-reaping)).
   In this case, 0.301 KSM are bonded for nominating, 0.3 KSM are bonded in a pool, and 0.145 KSM are
   not used for staking. Of the non-staking balance, 0.144 KSM are free while
-  [a small portion is reserved for the existential deposit](../chain-state-values.md#existential-deposit).
+  [a small portion is reserved for the existential deposit](../chain-state-values.md).
 
 - **Section F: The Recent Payouts Panel** shows a bar chart with the rewards paid out to you in the
   past 15 days either as a nominator or a pool member (manually claimed). Note how the 4th of April
@@ -137,7 +137,7 @@ This page of the dashboard has four main panels (Sidebar and Accounts Panels exc
 - **Section B: The Balance Panel** shows the number of tokens bonded in pools and those that are
   free. In this case, we have 0.3 KSM bonded and 0.144 KSM free. In this panel, you can bond more
   funds (`+` button) or unbond some funds (`-` button). Unbonding will withdraw unclaimed rewards
-  and funds will be locked for the [unbonding period](../chain-state-values.md#unbonding-duration).
+  and funds will be locked for the [unbonding period](../chain-state-values.md).
   Once the unbonding period has passed, you can unlock the locked funds (button with a lock icon)
   that will be available as a free balance.
 
@@ -209,8 +209,8 @@ pools that you liked (you can like a pool in the All Pools section by clicking o
 This page of the dashboard has four main panels (Sidebar and Accounts Panels excluded):
 
 - **Section A: The Stats Panel** shows the number of active nominators,
-  [the minimum number of tokens to nominate](../chain-state-values.md#minimum-bond-to-participate-in-staking)
-  and [the minimum active bond](../chain-state-values.md#minimum-active-bond). The system keeps 12500
+  [the minimum number of tokens to nominate](../chain-state-values.md)
+  and [the minimum active bond](../chain-state-values.md). The system keeps 12500
   nomination intents and puts them into the
   [bags list](../../learn/learn-staking-advanced.md#bags-list). The fact that active nominators are not
   12500 is because there are nominators that have no active validator.
@@ -218,7 +218,7 @@ This page of the dashboard has four main panels (Sidebar and Accounts Panels exc
   are free. In this case, we have 0.301 KSM bonded and 0.144 KSM free. In this panel, you can bond
   more funds (`+` button) or unbond some funds (`-` button). Unbonding will withdraw unclaimed
   rewards and funds will be locked for the
-  [unbonding period](../chain-state-values.md#unbonding-duration). Once the unbonding period has
+  [unbonding period](../chain-state-values.md). Once the unbonding period has
   passed, you can unlock the locked funds (button with a lock icon) that will be available as a free
   balance.
 

--- a/docs/general/glossary.md
+++ b/docs/general/glossary.md
@@ -643,7 +643,7 @@ software.
 ## Spend Period
 
 Successfully enacted Treasury track referenda will get funded at the end of the
-[spending period](./chain-state-values.md#treasury-spending-period). Treasury funds are directly
+[spending period](./chain-state-values.md). Treasury funds are directly
 sent to the beneficiary account at the end of the spend period.
 
 ## Staking

--- a/docs/kusama/kusama-inflation.md
+++ b/docs/kusama/kusama-inflation.md
@@ -21,7 +21,7 @@ KSM is an inflationary token. Inflation is set to be 10% annually. Depending on 
 and the ideal staking rate (more about this below), part of the inflation is distributed to the
 stakers and part to the [treasury](../learn/learn-polkadot-opengov-treasury.md).
 
-!!!info The current KSM token supply can be seen [here](../general/chain-state-values.md#total-issuance).
+!!!info The current KSM token supply can be seen [here](../general/chain-state-values.md).
 
 It is essential to understand that the primary objective of inflation is to incentivize network
 participants through

--- a/docs/learn/archive/learn-treasury.md
+++ b/docs/learn/archive/learn-treasury.md
@@ -26,7 +26,7 @@ The Treasury funds are held in a [system account](../learn-account-advanced.md#s
 accessible by anyone; only the system internal logic can access it. Funds can be spent by making a
 spending proposal that, if approved by the [Council](learn-governance.md#council), will enter a
 waiting period before distribution. This waiting period is known as the
-[_spend period_](../../general/chain-state-values.md#treasury-spending-period), and its duration is
+[_spend period_](../../general/chain-state-values.md), and its duration is
 subject to [governance](learn-governance.md). The Treasury attempts to spend as many proposals in
 the queue as it can without running out of funds.
 
@@ -35,7 +35,7 @@ Treasury payout is an automatic process:
 - If the Treasury funds run out with approved proposals left to fund, those proposals are kept in
   the approved queue, and will receive funding in the following spend period.
 - If the Treasury ends a spend period without spending all of its funds, it suffers a burn of
-  [a percentage of its funds](../../general/chain-state-values.md#treasury-burn-factor) - thereby
+  [a percentage of its funds](../../general/chain-state-values.md) - thereby
   causing deflationary pressure. This encourages the spending of the funds in the Treasury by
   Polkadot's governance system.
 

--- a/docs/learn/archive/thousand-validators.md
+++ b/docs/learn/archive/thousand-validators.md
@@ -112,7 +112,7 @@ determined by parsing data found [here](https://kusama.w3f.community/nominators)
 Since approximately early January 2021, the nominators will select an automatic number of validators
 to nominate based on the lowest amount staked for a validator and the amount of funds it holds. This
 can be anywhere from a few validators receiving nomination from a single nominator, to the
-[max of nominators](../../general/chain-state-values.md#maximum-votes-per-nominator).
+[max of nominators](../../general/chain-state-values.md).
 
 ## Selection
 

--- a/docs/learn/learn-DOT.md
+++ b/docs/learn/learn-DOT.md
@@ -89,12 +89,12 @@ the relay chain to benefit from Polkadot's security and interoperability.
 
 #### Total Issuance
 
-The [total issuance](../general/chain-state-values.md#total-issuance) is the total number of token
+The [total issuance](../general/chain-state-values.md) is the total number of token
 units in existence on the network.
 
 #### Inactive Issuance
 
-The [inactive issuance](../general/chain-state-values.md#inactive-issuance) is the total units of
+The [inactive issuance](../general/chain-state-values.md) is the total units of
 outstanding deactivated balance on the network that cannot be used for participation in governance.
 This comprises tokens locked away in crowdloans and nomination pools.
 

--- a/docs/learn/learn-account-advanced.md
+++ b/docs/learn/learn-account-advanced.md
@@ -371,7 +371,7 @@ nomination pool and parachain accounts as well.
 ## Indices
 
 Polkadot addresses can have indices. An index is like a short and easy-to-remember version of an
-address. Claiming an index requires [a deposit](../general/chain-state-values.md#index-deposit)
+address. Claiming an index requires [a deposit](../general/chain-state-values.md)
 released when the index is cleared. Any index can be claimed if it is not taken by someone else.
 
 But what if an account gets reaped, as explained above? In that case, the index is emptied. In other

--- a/docs/learn/learn-accounts.md
+++ b/docs/learn/learn-accounts.md
@@ -138,7 +138,7 @@ experience during this interim period.
 
 When you generate an account (address), you only generate a _key_ that lets you access it. The
 account does not exist yet on-chain. For that, it needs the
-[existential deposit](../general/chain-state-values.md#existential-deposit).
+[existential deposit](../general/chain-state-values.md).
 
 Having an account go below the existential deposit causes that account to be _reaped_. The account
 will be wiped from the blockchain's state to conserve space, along with any funds in that address.

--- a/docs/learn/learn-assets.md
+++ b/docs/learn/learn-assets.md
@@ -65,7 +65,7 @@ AssetHub. Learn more about asset conversion on AssetHub,
     See [this technical explainer video](https://youtu.be/knNLZEyposM?list=PLOyWqupZ-WGuAuS00rK-pebTMAOxW41W8&t=63) to learn how to create fungible assets on the Asset Hub.
 
 Anyone on the network can create assets on the Asset Hub as long as they can reserve the
-[required deposits](../general/chain-state-values.md#asset-deposit). The network reserves the
+[required deposits](../general/chain-state-values.md). The network reserves the
 deposit on creation. The creator also must specify a unique `AssetId`, an integer of type `u32`, to
 identify the asset. The `AssetId` should be the canonical identifier for an asset, as the chain does
 not enforce the uniqueness of metadata like "name" and "symbol". The creator must also specify a

--- a/docs/learn/learn-guides-accounts-multisig.md
+++ b/docs/learn/learn-guides-accounts-multisig.md
@@ -76,7 +76,7 @@ signatories to approve the call before finally executing it.
 ### Multisig Call Deposit
 
 When you create a new multi-sig call, you will need to place a
-[deposit](../general/chain-state-values.md#multisig-deposit-base). The deposit stays locked until
+[deposit](../general/chain-state-values.md). The deposit stays locked until
 the call is executed. This deposit is to establish an economic cost on the storage space that the
 multisig call takes up in the chain state and discourage users from creating multisig calls that
 never get executed. The deposit will be reserved in the call initiator's account.
@@ -87,8 +87,8 @@ The deposit is dependent on the `threshold` parameter and is calculated as follo
 Deposit = depositBase + threshold * depositFactor
 ```
 
-Where [`depositBase`](../general/chain-state-values.md#multisig-deposit-base) and
-[`depositFactor`](../general/chain-state-values.md#multisig-deposit-factor) are chain constants set
+Where [`depositBase`](../general/chain-state-values.md) and
+[`depositFactor`](../general/chain-state-values.md) are chain constants set
 in the runtime code.
 
 The other signatory accounts should have enough funds to pay for the transaction fees associated

--- a/docs/learn/learn-guides-assets-create.md
+++ b/docs/learn/learn-guides-assets-create.md
@@ -40,7 +40,7 @@ For additional background on the Asset Hub check out
 **The images in the guides below are for Polkadot, but they also apply to Kusama.**
 
 To create an asset on the Asset Hub, you would need to
-[deposit some funds](../general/chain-state-values.md#asset-deposit). Before you create an asset on
+[deposit some funds](../general/chain-state-values.md). Before you create an asset on
 the Asset Hub, ensure that your Asset Hub account balance is a bit more than the sum of those two
 deposits, which should seamlessly account for the required deposits and transaction fees. You can
 send the native token from a relay chain account to a the Asset Hub account using the teleport

--- a/docs/learn/learn-guides-bounties.md
+++ b/docs/learn/learn-guides-bounties.md
@@ -71,7 +71,7 @@ medium to explain the proposal, for example a bounty proposal document on
 can be used to submit all the information needed by OpenGov voters to make an informed decision.
 
 Submitting a bounty proposal will require a
-[deposit](../general/chain-state-values.md#bounty-deposit).
+[deposit](../general/chain-state-values.md).
 
 ## Assign a Curator to a Bounty
 

--- a/docs/learn/learn-guides-coretime-parachains.md
+++ b/docs/learn/learn-guides-coretime-parachains.md
@@ -59,7 +59,7 @@ Polkadot-SDK repository.
 ## Reserve ParaID
 
 Reserving a `ParaID` requires a
-[deposit](../general/chain-state-values.md#parachain-id-registration-deposit). The first step is to
+[deposit](../general/chain-state-values.md). The first step is to
 register a [`ParaID`](../general/glossary.md#paraid) for the parachain. This can be done through
 Polkadot-JS UI by navigating to
 [Network > Parachains > Parathreads](https://polkadot.js.org/apps/#/parachains/parathreads) and

--- a/docs/learn/learn-guides-identity.md
+++ b/docs/learn/learn-guides-identity.md
@@ -116,7 +116,7 @@ use it to set a sub-identity to your Ledger account.
 
 You should now see the sub-identity displayed on-chain. You need to be aware that the creation of
 identities and sub-identities requires
-[deposits](../general/chain-state-values.md#identity-deposit). This reserved account balance is
+[deposits](../general/chain-state-values.md). This reserved account balance is
 freed once you [clear the identities](../learn/learn-guides-identity.md#clearing-and-killing-an-identity)
 on the account.
 

--- a/docs/learn/learn-guides-nominator.md
+++ b/docs/learn/learn-guides-nominator.md
@@ -90,7 +90,7 @@ earn compound interest.
 
 You are now bonded. Being bonded means your tokens are locked and could be
 [slashed](./learn-offenses.md) if the validators you nominate misbehave. All bonded funds can be
-distributed to [multiple validators](../general/chain-state-values.md#maximum-votes-per-nominator).
+distributed to [multiple validators](../general/chain-state-values.md).
 Be careful about the validators you choose since you will be slashed if your validator commits an
 [offence](./learn-offenses.md).
 

--- a/docs/learn/learn-guides-polkadot-opengov.md
+++ b/docs/learn/learn-guides-polkadot-opengov.md
@@ -271,7 +271,7 @@ The submission deposit can be claimed by issuing the `refundSubmissionDeposit` e
 Users can not refund their submission deposit while the referendum is `Ongoing` or `Rejected`.
 Similarly, users cannot refund their submission deposit if the proposal has `TimedOut` (failing to
 submit the decision deposit
-[within specific period](../general/chain-state-values.md#opengov-referendum-timeout) will lead to a
+[within specific period](../general/chain-state-values.md) will lead to a
 referendum timeout). This behavior exists so that users can refrain from spamming the chain with
 proposals that have no interest from the community. If a proposal is in the `TimedOut` state, any
 user can call `slash_proposal_deposit`, which will move the funds from the user to a
@@ -321,14 +321,14 @@ button.
 You must specify the account to submit the proposal (this can differ from the account used to create
 the preimage). Then you will need to specify the track `20 / Referendum Canceller` and add the
 preimage hash containing the specific action that will be enacted if the referendum passes. Note
-that a [submission deposit](../general/chain-state-values.md#opengov-submission-deposit) will be
+that a [submission deposit](../general/chain-state-values.md) will be
 reserved for submitting the proposal.
 
 Once the proposal has been submitted, it will stay in the Lead-in period until there is enough space
 within the track, and a
 [track-dependent preparation period and decision deposit](./learn-polkadot-opengov-origins.md#polkadot-opengov-terminology-and-parameters)
 have been met. Failing to submit the decision deposit will ultimately lead to a
-[referendum timeout](../general/chain-state-values.md#opengov-referendum-timeout).
+[referendum timeout](../general/chain-state-values.md).
 
 ## Interpreting On-Chain Voting Data
 

--- a/docs/learn/learn-guides-staking-pools.md
+++ b/docs/learn/learn-guides-staking-pools.md
@@ -32,7 +32,7 @@ have some skin in the game. A significant stake from the depositor is always a g
 pool's credibility.
 
 The current minimum bond to create a pool can be found
-[here](../general/chain-state-values.md#minimum-bond-to-create-a-nomination-pool).
+[here](../general/chain-state-values.md).
 
 The pool’s ‘nominator role’ selects validators with the nominate extrinsic. On Polkadot JS Apps UI,
 navigate to Network > Staking > Pools and click on Add Pool button.

--- a/docs/learn/learn-guides-transfers.md
+++ b/docs/learn/learn-guides-transfers.md
@@ -60,7 +60,7 @@ In Polkadot there are two main ways to transfer funds from one account to anothe
 
 - `transfer keep-alive` (default option) will not allow you to send an amount that would allow the
   sending account to be removed due to it going below the
-  [existential deposit](../general/chain-state-values.md#existential-deposit).
+  [existential deposit](../general/chain-state-values.md).
 - `transfer allow-death` will allow you to send tokens regardless of the consequence. If the balance
   drops below the existential deposit your account will be reaped. It may be that you do not want to
   keep the account alive (for example, because you are moving all of your funds to a different
@@ -68,7 +68,7 @@ In Polkadot there are two main ways to transfer funds from one account to anothe
   [this support article](https://support.polkadot.network/support/solutions/articles/65000169248).
 
 !!!info
-    Attempting to send less than the [existential deposit](../general/chain-state-values.md#existential-deposit) to an account with zero balance will always fail, no matter if the keep-alive check is on or not.
+    Attempting to send less than the [existential deposit](../general/chain-state-values.md) to an account with zero balance will always fail, no matter if the keep-alive check is on or not.
 
 Even if the transfer fails due to a keep-alive check, the transaction fee will be deducted from the
 sending account if you attempt to transfer.

--- a/docs/learn/learn-guides-treasury.md
+++ b/docs/learn/learn-guides-treasury.md
@@ -301,6 +301,6 @@ Briefly, you will need to:
   or [the Kusama Direction Element Channel](https://matrix.to/#/#Polkadot-Direction:parity.io) about
   your referendum
 - Place the decision deposit
-  [before the timeout](../general/chain-state-values.md#opengov-referendum-timeout)
+  [before the timeout](../general/chain-state-values.md)
 - Once the referendum ends you can
   [claim the preimage and decision deposits back](./learn-guides-polkadot-opengov.md#claiming-the-preimage-and-decision-deposits)

--- a/docs/learn/learn-identity.md
+++ b/docs/learn/learn-identity.md
@@ -14,7 +14,7 @@ Polkadot provides a naming system that allows participants to add personal infor
 on-chain account and subsequently ask for verification of this information by
 [registrars](#registrars).
 
-Users must [reserve funds](../general/chain-state-values.md#identity-deposit) in a bond to store
+Users must [reserve funds](../general/chain-state-values.md) in a bond to store
 their information on chain. These funds are _locked_, not spent - they are returned when the
 identity is cleared.
 
@@ -33,7 +33,7 @@ register multiple sub accounts that represent the [Stash accounts](learn-cryptog
 their validators.
 
 An account can have a maximum of 100 sub-accounts. Note that a
-[deposit](../general/chain-state-values.md#sub-identity-deposit) is required for every sub-account.
+[deposit](../general/chain-state-values.md) is required for every sub-account.
 
 ## Judgements
 

--- a/docs/learn/learn-nomination-pools.md
+++ b/docs/learn/learn-nomination-pools.md
@@ -81,7 +81,7 @@ ability to bond additional funds or re-stake rewards as long as they are already
 Note that a member may only belong to one pool at a time.
 
 The current minimum bond to join a pool can be seen
-[here](../general/chain-state-values.md#minimum-bond-to-join-a-nomination-pool).
+[here](../general/chain-state-values.md).
 
 !!!info
     The funds nominated to a pool will not be visible in the member's account balance on Polkadot JS Apps UI. This is because the member funds are transferred from their account to the pool's [system account](./learn-account-advanced.md#system-accounts). This pool account is not accessible by anyone (including the pool root or depositor) and only the pool's internal logic can access the account.
@@ -125,7 +125,7 @@ learn how to claim rewards for another pool member.
 
 At any point in time after joining the pool, a member can start the process of exiting by unbonding.
 `unbond` will unbond part or all of the member's funds. After unbond has been called and the
-[unbonding duration](../general/chain-state-values.md#unbonding-duration) has passed a member may
+[unbonding duration](../general/chain-state-values.md) has passed a member may
 withdraw their funds with `withdrawUnbonded`. Withdrawing effectively ends a member's relationship
 with their pool, allowing them to join a different pool if desired. Check the "Withdraw unbonded
 funds" section in
@@ -175,7 +175,7 @@ Three methods can be used when setting the pool commission:
 
 - **Commission Rate** (`nominationPools.setCommission` extrinsic): the start or new commission rate
   (`newCommission` parameter) that can be set between 0% and the
-  [max commission parameter](../general/chain-state-values.md#nomination-pool-max-commission)
+  [max commission parameter](../general/chain-state-values.md)
   (decided through [governance referendum](./learn-polkadot-opengov.md)) via the
   [`globalMaxCommission`](https://paritytech.github.io/substrate/master/pallet_nomination_pools/pallet/type.GlobalMaxCommission.html)
   parameter. You will need to specify an Input Payee Account, i.e. the account that will receive the
@@ -241,9 +241,9 @@ Nominating is an active task, which implies that you regularly monitor that your
 active validator in all the eras and check if you are receiving your staking rewards. More
 importantly, ensure that the validators you chose always act in the best interests of the network
 protocol and have less chance of getting [slashed](./learn-offenses.md). To nominate you need a
-[minimum bond](../general/chain-state-values.md#minimum-bond-to-participate-in-staking), while to
+[minimum bond](../general/chain-state-values.md), while to
 receive rewards, you need at least a balance greater than the
-[minimum active bond](../general/chain-state-values.md#minimum-active-bond). If the validator
+[minimum active bond](../general/chain-state-values.md). If the validator
 misbehaves, It is worth noting that your stake is subject to slashing, irrespective of whether you
 are at the top nominators or not.
 
@@ -262,7 +262,7 @@ to act in your best interests. However, it is advised to check the validators no
 from time to time and change the pool if necessary.
 
 !!!info "Minimum Active Nomination Value is Dynamic"
-    The minimum amount required to become an active nominator and earn rewards can be seen [here](../general/chain-state-values.md#minimum-active-bond). If you have less tokens than the minimum active nomination and still want to participate in staking, you can join the nomination pools with a [smaller bond](../general/chain-state-values.md#minimum-bond-to-participate-in-staking). For additional information, see [this blog post](https://polkadot.network/blog/nomination-pools-are-live-stake-natively-with-just-1-dot/). Check the wiki doc on [nomination pools](learn-nomination-pools.md) for more information.
+    The minimum amount required to become an active nominator and earn rewards can be seen [here](../general/chain-state-values.md). If you have less tokens than the minimum active nomination and still want to participate in staking, you can join the nomination pools with a [smaller bond](../general/chain-state-values.md). For additional information, see [this blog post](https://polkadot.network/blog/nomination-pools-are-live-stake-natively-with-just-1-dot/). Check the wiki doc on [nomination pools](learn-nomination-pools.md) for more information.
 
 |                                                                                                                                 Nominating                                                                                                                                  |                                                                                                              Joining a Pool                                                                                                               |
 | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |

--- a/docs/learn/learn-nominator.md
+++ b/docs/learn/learn-nominator.md
@@ -15,7 +15,7 @@ slug: ../learn-nominator
     You can now [stake natively with just 1 DOT and earn staking rewards](https://polkadot.network/blog/nomination-pools-are-live-stake-natively-with-just-1-dot/).
 
 !!!info "Stake through Nomination Pools"
-    The minimum amount required to become an active nominator (i.e. the [minimum active bond](../general/chain-state-values.md#minimum-active-bond)) and earn rewards may change from era to era. If you have less tokens than the minimum active nomination and still want to participate in staking, you can join the nomination pools with a [smaller amount of tokens](../general/chain-state-values.md#minimum-bond-to-participate-in-staking). For additional information, see
+    The minimum amount required to become an active nominator (i.e. the [minimum active bond](../general/chain-state-values.md)) and earn rewards may change from era to era. If you have less tokens than the minimum active nomination and still want to participate in staking, you can join the nomination pools with a [smaller amount of tokens](../general/chain-state-values.md). For additional information, see
     [this blog post](https://polkadot.network/blog/nomination-pools-are-live-stake-natively-with-just-1-dot/).
     Check the wiki doc on [nomination pools](learn-nomination-pools.md) for more information.
 
@@ -70,7 +70,7 @@ While your tokens are staked for nominations, they are 'locked' (bonded). You ca
 [stop nominating at any time](./learn-guides-nominator.md#stop-nominating), but remember that the
 action is effective in the next era and does not automatically unbond your funds. Unbonding is a
 separate action, and it takes effect after the
-[unbonding period](../general/chain-state-values.md#unbonding-duration). A staking lock will be
+[unbonding period](../general/chain-state-values.md). A staking lock will be
 visible on the Polkadot-JS UI during the unbonding period, and after it, the staking lock can be
 unlocked, and the bonded funds become free balance you can transfer.
 
@@ -145,7 +145,7 @@ metrics shown as an example, followed by a brief description of each.
   nominators whose stake in the current era is baking other validators.
 
   Every nominator can select up to
-  [a maximum number of validators](../general/chain-state-values.md#maximum-votes-per-nominator),
+  [a maximum number of validators](../general/chain-state-values.md),
   which contributes towards maximizing the probability of having the nominator’s stake applied to
   the validators active set. Nominating too few validators could result in the nominators not
   receiving their rewards when none of them make it to the active set or when those validators stop
@@ -330,7 +330,7 @@ nominate with to receive staking rewards can change between the eras.
 Thus, for **nominator counters**, we have:
 
 - count of nominator intentions and
-  [max possible nominator intentions](../general/chain-state-values.md#maximum-number-of-nominators)
+  [max possible nominator intentions](../general/chain-state-values.md)
 - count of electing nominators, and maximum possible electing nominators (22500 on Polkadot and
   12500 on Kusama)
 - count of active nominators and maximum possible active nominators (22500 on Polkadot and 12500 on
@@ -364,7 +364,7 @@ almost always see only a single active nomination per era. See the
 ### Minimum Active Nomination to Receive Staking Rewards
 
 !!!info "Minimum DOT required to earn staking rewards"
-    The [minimum number of tokens required to submit intent to nominate](../general/chain-state-values.md#minimum-bond-to-participate-in-staking) differs from the [minimum active nomination](../general/chain-state-values.md#minimum-active-bond) required to earn staking rewards.
+    The [minimum number of tokens required to submit intent to nominate](../general/chain-state-values.md) differs from the [minimum active nomination](../general/chain-state-values.md) required to earn staking rewards.
 
 ![Minimum Active Nomination](../assets/staking/min-active-nomination.png)
 

--- a/docs/learn/learn-phragmen.md
+++ b/docs/learn/learn-phragmen.md
@@ -604,7 +604,7 @@ to an off-chain worker, which validators can work on the problem without impacti
 time.
 
 To limit the complexity of the election and payout, any given nominator can only
-[select a limited number of validators](../general/chain-state-values.md#maximum-votes-per-nominator)
+[select a limited number of validators](../general/chain-state-values.md)
 to nominate.
 
 ### Phragmms (aka Balphragmms)

--- a/docs/learn/learn-polkadot-opengov-treasury.md
+++ b/docs/learn/learn-polkadot-opengov-treasury.md
@@ -32,7 +32,7 @@ mechanisms:
 The outflow is determined by the following mechanisms:
 
 - **Burned tokens:** at the end of each spend period,
-  **[a fraction](../general/chain-state-values.md#treasury-burn-factor) of the available funds are
+  **[a fraction](../general/chain-state-values.md) of the available funds are
   burned**.
 - **Treasury proposals & Bounties:** they make up the largest share of outflow tokens to the
   community and need to be approved by governance. Then, payouts occur at the end of a
@@ -146,7 +146,7 @@ total value of the bounty. In this sense, the curator's fee can be defined as th
 the amounts paid to child bounty awardees and the total value of the bounty.
 
 Curators are selected through OpenGov referendum after the bounty proposal passes; and they need to
-pay an upfront [deposit](../general/chain-state-values.md#bounty-curator-deposit) to take the
+pay an upfront [deposit](../general/chain-state-values.md) to take the
 position. This deposit can be used to punish curators if they act maliciously. However, if they are
 successful in managing the bounty to completion, they will receive their deposit back, and part of
 the bounty funding as a payment for their efforts.
@@ -158,7 +158,7 @@ mechanism. A Bounty is a reward for a specified body of work or set of objective
 executed for a predefined treasury amount designated to be paid out. The responsibility of assigning
 a payout address once the specified set of objectives is completed is delegated to the curator.
 
-The bounty has a [predetermined duration](../general/chain-state-values.md#bounty-duration), with
+The bounty has a [predetermined duration](../general/chain-state-values.md), with
 possible extension(s) to be requested by the curator. To maintain flexibility during the tasks’
 curation, the curator will also be able to create child bounties for more granularity in the
 allocation of funds and as part of a nested iteration of the bounty mechanism.

--- a/docs/learn/learn-polkadot-opengov.md
+++ b/docs/learn/learn-polkadot-opengov.md
@@ -267,7 +267,7 @@ double.
 <VLTable />
 
 The maximum number of "doublings" of the
-[lock period](../general/chain-state-values.md#conviction-voting-lock-period) is set to 6 (and thus
+[lock period](../general/chain-state-values.md) is set to 6 (and thus
 32 lock periods in total). For additional information regarding the timeline of governance events,
 check out the governance section on the
 [Polkadot Parameters page](../maintain/maintain-polkadot-parameters.md#governance).

--- a/docs/learn/learn-proxies.md
+++ b/docs/learn/learn-proxies.md
@@ -87,10 +87,10 @@ The required deposit amount for `n` proxies is equal to:
 
 `ProxyDepositBase` + `ProxyDepositFactor` \* `n`
 
-where the [`ProxyDepositBase`](../general/chain-state-values.md#proxy-deposits) is the required
+where the [`ProxyDepositBase`](../general/chain-state-values.md) is the required
 amount to be reserved for an account to have a proxy list (creates one new item in storage). For
 every proxy the account has, an additional amount defined by the
-[`ProxyDepositFactor`](../general/chain-state-values.md#proxy-deposits) is reserved as well (appends
+[`ProxyDepositFactor`](../general/chain-state-values.md) is reserved as well (appends
 33 bytes to storage location).
 
 ## Time-delayed Proxy
@@ -107,10 +107,10 @@ Announcing `n` calls using a time-delayed proxy also requires a deposit of the f
 
 `announcementDepositBase` + `announcementDepositFactor` \* `n`
 
-where the [`announcementDepositBase`](../general/chain-state-values.md#proxy-deposits) is the
+where the [`announcementDepositBase`](../general/chain-state-values.md) is the
 required amount to be reserved for an account to announce a proxy call. For every proxy call the
 account has, an additional amount defined by the
-[`announcementDepositFactor`](../general/chain-state-values.md#proxy-deposits) is reserved as well.
+[`announcementDepositFactor`](../general/chain-state-values.md) is reserved as well.
 
 ---
 

--- a/docs/learn/learn-staking-advanced.md
+++ b/docs/learn/learn-staking-advanced.md
@@ -22,7 +22,7 @@ slug: ../learn-staking-advanced
 ---
 
 !!!tip "New to Staking?"
-      Start your staking journey or explore more information about staking on [Polkadot's Home Page](https://polkadot.network/staking/). Discover the new [Staking Dashboard](https://staking.polkadot.cloud/#/overview) that makes staking much easier and check this [extensive article list](https://support.polkadot.network/support/solutions/articles/65000182104) to help you get started. You can now stake natively with a [small number of tokens](../general/chain-state-values.md#minimum-bond-to-join-a-nomination-pool) and earn staking rewards. For additional information, check out [this blog post](https://polkadot.network/blog/nomination-pools-are-live-stake-natively-with-just-1-dot/).
+      Start your staking journey or explore more information about staking on [Polkadot's Home Page](https://polkadot.network/staking/). Discover the new [Staking Dashboard](https://staking.polkadot.cloud/#/overview) that makes staking much easier and check this [extensive article list](https://support.polkadot.network/support/solutions/articles/65000182104) to help you get started. You can now stake natively with a [small number of tokens](../general/chain-state-values.md) and earn staking rewards. For additional information, check out [this blog post](https://polkadot.network/blog/nomination-pools-are-live-stake-natively-with-just-1-dot/).
 
 This page is meant to be an advanced guide to staking with the relay chain. For a more general
 introduction, checkout the [Introduction to Staking](./learn-staking.md) page.
@@ -358,7 +358,7 @@ A maximum of
 [`pallet::Config::SignedMaxSubmissions`](https://github.com/paritytech/polkadot-sdk/blob/f610ffc05876d4b98a14cee245b4cc27bd3c0c15/runtime/polkadot/src/lib.rs#L390)
 will be stored on-chain and they will be sorted based on score. Higher the score the more optimal
 the election solution is. The
-[`SignedMaxSubmissions`](../general/chain-state-values.md#staking-miner-max-submissions) variable
+[`SignedMaxSubmissions`](../general/chain-state-values.md) variable
 can be modified through governance.
 
 Upon arrival of a new solution:

--- a/docs/learn/learn-staking.md
+++ b/docs/learn/learn-staking.md
@@ -23,7 +23,7 @@ slug: ../learn-staking
     Explore Polkadot with a secure and user-friendly wallets listed on the [Polkadot website](https://www.polkadot.network/ecosystem/wallets/) and start your staking journey or explore more information about staking on [Polkadot's Staking Page](https://polkadot.network/staking/). Discover the new [Staking Dashboard](https://staking.polkadot.cloud/#/overview) that makes staking much easier and check this [extensive article list](https://support.polkadot.network/support/solutions/articles/65000182104) to help you get started. The dashboard supports [Ledger](../general/ledger.md) devices natively and does not require an extension or wallet as an interface.
 
 !!!info "Stake through Nomination Pools"
-    The minimum amount required to become an active nominator (i.e. [the minimum active bond](../general/chain-state-values.md#minimum-active-bond)) and earn rewards may change from era to era. If you have less tokens than the minimum active nomination and still want to participate in staking, you can join the nomination pools with a [minimal bond](../general/chain-state-values.md#minimum-bond-to-join-a-nomination-pool) and earn staking rewards. For additional information, check out [this blog post](https://polkadot.network/blog/nomination-pools-are-live-stake-natively-with-just-1-dot/). Check the wiki doc on [nomination pools](learn-nomination-pools.md) for more information.
+    The minimum amount required to become an active nominator (i.e. [the minimum active bond](../general/chain-state-values.md)) and earn rewards may change from era to era. If you have less tokens than the minimum active nomination and still want to participate in staking, you can join the nomination pools with a [minimal bond](../general/chain-state-values.md) and earn staking rewards. For additional information, check out [this blog post](https://polkadot.network/blog/nomination-pools-are-live-stake-natively-with-just-1-dot/). Check the wiki doc on [nomination pools](learn-nomination-pools.md) for more information.
 
 Here you will learn about what staking is, why it is important, and how it works.
 
@@ -77,20 +77,20 @@ and sophisticated mechanism to select the validators who are allowed to particip
 
 Any potential validators can indicate their intention to be a validator candidate. Their candidacies
 are made public to all nominators, and a nominator, in turn, submits a
-[capped list of candidates](../general/chain-state-values.md#maximum-votes-per-nominator) that it
+[capped list of candidates](../general/chain-state-values.md) that it
 supports, and the network will automatically distribute the stake among validators in an even manner
 so that the economic security is maximized. In the next era, a certain number of validators having
 the highest backing get elected and become active. For more information about the election algorithm
 go to [this](learn-phragmen.md) page on the wiki or
 [this](https://research.web3.foundation/Polkadot/protocols/NPoS/Paper) research article. As a
-nominator, a [minimum bond](../general/chain-state-values.md#minimum-bond-to-participate-in-staking)
+nominator, a [minimum bond](../general/chain-state-values.md)
 is required to submit an intention to nominate, which can be thought of as registering to be a
 nominator. Note that in NPoS the stake of both nominators and validators can be
 [slashed](./learn-offenses.md). For an in-depth review of NPoS see
 [this](https://research.web3.foundation/Polkadot/protocols/NPoS/Overview) research article.
 
 !!!caution "Minimum Nomination to Receive Staking Rewards"
-    [The minimum nomination intent](../general/chain-state-values.md#minimum-bond-to-participate-in-staking) does not guarantee staking rewards. The nominated amount has to be greater than [minimum active nomination](../general/chain-state-values.md#minimum-active-bond), which is a dynamic value that can be much higher than the minimum nomination intent. This dynamic value depends on the amount of tokens being staked, in addition to the selected nominations.
+    [The minimum nomination intent](../general/chain-state-values.md) does not guarantee staking rewards. The nominated amount has to be greater than [minimum active nomination](../general/chain-state-values.md), which is a dynamic value that can be much higher than the minimum nomination intent. This dynamic value depends on the amount of tokens being staked, in addition to the selected nominations.
 
 ### Nominating Validators
 
@@ -330,7 +330,7 @@ The distribution of staking rewards to the nominators is not automatic and needs
 someone. Typically the validators take care of this, but anyone can permissionlessly trigger rewards
 payout for all the nominators whose stake has backed a specific validator in the active set of that
 era. Staking rewards are kept available for
-[a limited amount of time](../general/chain-state-values.md#staking-reward-retention).
+[a limited amount of time](../general/chain-state-values.md).
 
 For more information on why this is so, see the page on [simple payouts](learn-staking-advanced.md).
 
@@ -374,7 +374,7 @@ this wiki.
     If you accidentally bonded your tokens or your bonded tokens never backed any active validator, you can now unbond them immediately.
 
 If your bonded balance did not back any validators for a
-[pre-determined period](../general/chain-state-values.md#bounty-duration), you are eligible to
+[pre-determined period](../general/chain-state-values.md), you are eligible to
 perform fast unstaking. The [staking dashboard](https://staking.polkadot.cloud/#/overview) will
 automatically check if you qualify. For more information, visit the
 ["Fast Unstake" section in this support article](https://support.polkadot.network/support/solutions/articles/65000169433-can-i-transfer-dot-without-unbonding-and-waiting-28-days-).
@@ -385,7 +385,7 @@ automatically check if you qualify. For more information, visit the
 
 - Earn rewards for contributing to the network's security through staking.
 - Low barrier of entry through [Nomination Pools](learn-nomination-pools.md).
-- Can choose [multiple validators](../general/chain-state-values.md#maximum-votes-per-nominator)
+- Can choose [multiple validators](../general/chain-state-values.md)
   which can help to decentralize the network through the sophisticated
   [NPoS system](./learn-consensus.md#nominated-proof-of-stake)
 - 85% of inflation/year of the tokens is primarily intended for staking rewards. Check the
@@ -394,7 +394,7 @@ automatically check if you qualify. For more information, visit the
 ### Cons of Staking
 
 - Tokens will be locked during the
-  [unbonding period](../general/chain-state-values.md#unbonding-duration) and no rewards will be
+  [unbonding period](../general/chain-state-values.md) and no rewards will be
   earned if you unbond.
 - Possible punishment in case of the active validator found to be misbehaving (see
   [slashing](./learn-offenses.md)).
@@ -403,24 +403,24 @@ automatically check if you qualify. For more information, visit the
 
 #### Unbonding Period Length
 
-The [unbonding period](../general/chain-state-values.md#unbonding-duration) provides a safety net
+The [unbonding period](../general/chain-state-values.md) provides a safety net
 for slashing offenses identified in
 [past eras](https://research.web3.foundation/Polkadot/security/slashing/npos#slashing-in-past-eras),
 which can hold the respective validators and their nominators accountable. The unbonding period is
 crucial in mitigating ex post facto slashing, particularly in guarding against long-range attacks.
 When a client encounters a chain finalized by
 [GRANDPA](./learn-consensus.md#finality-gadget-grandpa) that originates more than one
-[unbonding period](../general/chain-state-values.md#unbonding-duration) in the past, it lacks the
+[unbonding period](../general/chain-state-values.md) in the past, it lacks the
 security of slashing protection.
 
 Essentially, this period establishes a cadence for synchronizing with the chain or acquiring a
 checkpoint within a timeframe that engenders trust. It's worth noting that while the choice of
-[unbonding period length](../general/chain-state-values.md#unbonding-duration) is somewhat
+[unbonding period length](../general/chain-state-values.md) is somewhat
 arbitrary, it unquestionably provides a higher level of security compared to a shorter period.
 
 ## How many Validators?
 
-The top bound on the [number of validators](../general/chain-state-values.md#active-validator-count)
+The top bound on the [number of validators](../general/chain-state-values.md)
 has not been determined yet, but should only be limited by the bandwidth strain of the network due
 to peer-to-peer message passing.
 

--- a/docs/learn/learn-validator.md
+++ b/docs/learn/learn-validator.md
@@ -28,7 +28,7 @@ relay chain.
 
 Para-validators work in groups and are selected by the runtime in every epoch to validate parachain
 blocks for all parachains connected to the relay chain. The selected para-validators are part of the
-[active validators](../general/chain-state-values.md#active-validator-count) randomly selected (per
+[active validators](../general/chain-state-values.md) randomly selected (per
 epoch) to participate in the validation, creating a validator pool of 200 para-validators.
 
 Para-validators verify that the information contained in an assigned set of parachain blocks is

--- a/docs/maintain/kusama/maintain-guides-how-to-validate-kusama.md
+++ b/docs/maintain/kusama/maintain-guides-how-to-validate-kusama.md
@@ -63,7 +63,7 @@ On Kusama, one day is approximately four eras whereas on Polkadot, one era is ap
 In each era, the validators elected to the active set earn era points which correspond to the actual
 rewards earned that are distributed proportionally to the nominators after deducting the validator
 commission. The
-[minimum validator commission](../../general/chain-state-values.md#minimum-validator-commission) can
+[minimum validator commission](../../general/chain-state-values.md) can
 be set through on-chain governance. For more information rewards and payouts, check the
 [validator payout](../maintain-guides-validator-payout.md) document.
 

--- a/docs/maintain/maintain-guides-how-to-validate-polkadot.md
+++ b/docs/maintain/maintain-guides-how-to-validate-polkadot.md
@@ -489,7 +489,7 @@ below are a few public snapshot providers for Polkadot and Kusama.
 
 ## Bond DOT
 
-There is a [minimum bond](../general/chain-state-values.md#minimum-validator-bond) to start a
+There is a [minimum bond](../general/chain-state-values.md) to start a
 validator instance, but to enter the active validator set and be eligible to earn rewards, your
 validator node should be nominated by a minimum number of DOT tokens.
 

--- a/docs/maintain/maintain-polkadot-parameters.md
+++ b/docs/maintain/maintain-polkadot-parameters.md
@@ -68,7 +68,7 @@ a block in the chain. Thus, the times given are *estimates*. See
 ### Staking, Validating, and Nominating
 
 The maximum number of validators that can be nominated by a nominator is can be see
-[here](../general/chain-state-values.md#maximum-votes-per-nominator).
+[here](../general/chain-state-values.md).
 
 === "Polkadot"
 


### PR DESCRIPTION
### Pull Request Summary
This PR removes the informational messages that appear when compiling the wiki locally without macros enabled.

### Background
The INFO messages were caused by broken anchors linking to specific subtitles within the chain state page. Instead of directing users to precise subtitles, the links would only navigate to the general chain state page. Additionally, some subtitles are shared across different chains, which is why the table of contents (TOC) has been disabled beyond the 4th level.

### Context
The chain state page was designed as a centralized reference for changing values. Instead of manually searching for specific values, users are expected to retrieve them using the AI chatbot.

