### PR TITLE
Remove Site Name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 # Project information
-site_name: "Polkadot Wiki"
+site_name: ""
 site_url: https://w3f.github.io/polkadot-wiki-mkdocs
 site_author: Web3 Foundation Technologies
 site_description: >-


### PR DESCRIPTION
This remove the display of "Polkadot Wiki" next to the Logo